### PR TITLE
expansionについて調査報告

### DIFF
--- a/search/expansion.txt
+++ b/search/expansion.txt
@@ -1,0 +1,215 @@
+シェル変数が複数の場合
+bash-3.2$ SP="out ls"
+bash-3.2$ echo $SP
+out ls
+bash-3.2$ echo "$SP"
+out ls
+bash-3.2$ echo '$SP'
+$SP
+
+シェル変数＋文字が入った場合
+bash-3.2$ echo $SPl
+
+bash-3.2$ echo "$SP"l
+out lsl
+bash-3.2$ echo '$SP'l
+$SPl
+
+リダイレクトかつシェル変数が単体の場合
+結果　
+通常とダブルクウォートの場合は展開される
+シングルクウォートの場合は変数展開しない
+bash-3.2$ SP=A
+bash-3.2$ >$SP
+bash-3.2$ ls
+A               expansion.txt
+bash-3.2$ >"$SP"
+bash-3.2$ ls
+A               expansion.txt
+bash-3.2$ >'$SP'
+bash-3.2$ ls
+$SP             A               expansion.txt
+
+リダイレクトかつシェル変数が複数単語の場合
+結果　
+通常の場合はリダイレクトエラー
+ダブルクウォートの場合は一つの単語として認識される。
+シングルクウォートの場合は変数展開しない
+bash-3.2$ SP="out ls"
+bash-3.2$ >$SP
+bash: $SP: ambiguous redirect
+bash-3.2$ >"$SP"
+bash-3.2$ ls
+$SP             A               expansion.txt   out ls
+bash-3.2$ >'$SP'
+bash-3.2$ ls
+$SP             A               expansion.txt   out ls
+
+リダイレクトかつファイルの名前outがありかつシェル変数がファイルとコマンドが入っている場合
+結果
+通常の場合、リダイレクト
+bash-3.2$ <out ls
+A               expansion.txt   out
+bash-3.2$ SP="out ls"
+bash-3.2$ <$SP
+bash: $SP: ambiguous redirect
+bash-3.2$ <"$SP"
+bash: out ls: No such file or directory
+bash-3.2$ <'$SP'
+bash: $SP: No such file or directory
+
+環境変数の場合も同様
+bash-3.2$ export SP="out ls"
+bash-3.2$ >$SP
+bash: $SP: ambiguous redirect
+bash-3.2$ <$SP
+bash: $SP: ambiguous redirect
+bash-3.2$ ls
+A               expansion.txt   out
+bash-3.2$ <"$SP"
+bash: out ls: No such file or directory
+bash-3.2$ <'$SP'
+bash: $SP: No such file or directory
+
+課題で実装する必要がある特殊文字をシェル変数に入れた場合
+結果　制御文字とパイプは入力待ち状態になる（クウォートが奇数個の時と一緒）
+bash-3.2$ SP=&&
+> 
+bash-3.2$ S=&&
+> 
+bash-3.2$ echo $S
+
+bash-3.2$ S=||
+> 
+bash-3.2$ S=|
+> 
+bash-3.2$ S=>
+bash: syntax error near unexpected token `newline'
+bash-3.2$ S=<
+bash: syntax error near unexpected token `newline'
+
+クウォートをシェル変数に入れた場合
+結果　コマンドの場合は空白として認識され、echoの場合は改行が出力された(valueがない場合はこのような挙動になるe)
+bash-3.2$ S=''
+bash-3.2$ $S
+bash-3.2$ 
+bash-3.2$ echo $S
+
+bash-3.2$
+bash-3.2$ S=""
+bash-3.2$ $S
+bash-3.2$ 
+bash-3.2$ echo $S
+
+bash-3.2$ 
+bash-3.2$ set
+S=
+
+空文字を直接入力した場合とシェル変数に格納した場合の違い
+結果　シェル変数はvalueが入っていたので、エラーを吐いていない
+bash-3.2$ ''
+bash: : command not found
+bash-3.2$ S=''
+bash-3.2$ $S
+bash-3.2$ 
+
+bash-3.2$ S=''''
+bash-3.2$ set | grep S=
+S=
+bash-3.2$ S='""'
+bash-3.2$ set | grep S=
+S='""'
+bash-3.2$ S="''"
+bash-3.2$ set | grep S=
+//'\''が二つ（バックスラッシュなので実装するか検討）
+S=''\'''\'''
+
+シェル変数や環境変数にシェル変数を代入する
+結果　通常とダブルクウォートは変数展開された値が代入される
+bash-3.2$ S=AD
+bash-3.2$ SP=$S
+bash-3.2$ echo $SP
+AD
+bash-3.2$ SP="$S"
+bash-3.2$ echo $SP
+kk
+bash-3.2$ S=A
+bash-3.2$ export SP="$S"
+bash-3.2$ echo $SP
+A
+bash-3.2$
+bash-3.2$ SP='$S'
+bash-3.2$ echo $SP
+$S
+
+bash-3.2$ SP="$d"$d"$"d"$d"
+bash-3.2$ echo $SP
+$d
+bash-3.2$ SP="$d$d$d$d"
+bash-3.2$ echo $SP
+
+bash-3.2$ SP="$d$d$dd"
+bash-3.2$ echo $SP
+
+bash-3.2$ SP="d$ddd"
+bash-3.2$ echo $SP
+d
+bash-3.2$ SP="$"
+bash-3.2$ echo $SP
+$
+bash-3.2$ SP="$d"
+bash-3.2$ echo $SP
+
+//リダイレクトが先に実行される
+//おおむね英数字以外の場合は区切られるから
+bash-3.2$ 
+bash-3.2$ echo $d$"S"
+S
+bash-3.2$ echo $d$d"S"
+S
+bash-3.2$ echo d$dd"S"
+dS
+bash-3.2$ 
+
+bash-3.2$ echo $SP
+||
+bash-3.2$ echo ||
+> ls
+
+bash-3.2$ 
+bash-3.2$ export SP="||"
+bash-3.2$ set | grep SP=
+SP='||'
+bash-3.2$ export | grep SP=
+declare -x SP="||"
+bash-3.2$ env | grep SP=
+SP=||
+
+ls || echo a
+bash-3.2$ ls $SP echo a
+ls: echo: No such file or directory
+ls: ||: No such file or directory
+a
+
+環境変数、シェル変数に制御演算子やメタ文字を入れても課題要件役割を果たさない
+
+以下課題要件外
+${parameter:-word}
+${parameter:=word}
+${parameter:?word}
+${parameter:+word}
+${parameter:offset}
+${parameter:offset:length}
+${!prefix*}
+${!prefix@}
+${!name[@]}
+${!name[*]}
+${#parameter}
+${parameter#word}
+${parameter##word}
+${parameter%word}
+${parameter%%word}
+${parameter/pattern/string}
+${parameter//pattern/string}
+${parameter/#pattern/string}
+${parameter/%pattern/string}


### PR DESCRIPTION
以下のことがわかった。
- リダイレクトを使用する場合
  - 直接既存のファイル名とコマンドを実行した場合、実行された
  - 環境変数、シェル変数に既存のファイル名、コマンドを代入し、その変数で実行した場合、通常時はリダイレクトエラーが起こり、クウォートの場合はディレクトリ、ファイルがないよエラーになった。
- 課題で実装する必要がある特殊文字をシェル変数に入れた場合,制御文字とパイプは入力待ち状態になる
- クウォートをシェル変数に入れた場合、変数としてvalueが設定されていないため空白文字の認識となった。
- シェル変数や環境変数にシェル変数を代入した場合、通常とダブルクウォートは変数展開された値が代入された。（bashのクウォートの説明に書いてある法則に従ってある）
- 環境変数、シェル変数に課題要件に関連する制御演算子を文字列として入れてもただの文字列扱いとなる。

感想や気付き
- 調査をする前にあらかじめリファレンスを読み、その知識を実際に使って検証する方が時間効率がいいと思った。
- 調査内容をあらかじめ決める、もしくは具体的に何が知りたいのかを書けばよかった。
- もう一度クウォート周りのリファレンスを読む