### PR TITLE
標準入力待ちのコマンドのバグ修正（cat | ls）

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/14 15:49:20 by hsawamur          #+#    #+#             */
-/*   Updated: 2023/08/31 12:41:07 by tyamauch         ###   ########.fr       */
+/*   Updated: 2023/09/01 14:40:51 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,7 @@ typedef struct s_command
 	t_redirect_list			*redirect_list;
 	int						fd;
 	pid_t					pid;
+	bool					redirect_success;
 }							t_command;
 
 typedef struct s_ast

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/22 13:02:01 by hsawamur          #+#    #+#             */
-/*   Updated: 2023/08/30 21:30:33 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/01 14:50:43 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,13 +106,17 @@ static void	exec_child_node(t_ast *node, t_operator operator, t_data *d)
  */
 void	exec_command(t_ast *node, t_operator operator, t_data *d)
 {
+	bool	rd_success;
+
 	exec_child_node(node, operator, d);
 	if (node->type == PS_COMMAND)
 	{
-		if (exec_do_redirection(node, d) == false)
-			return ;
+		node->command_list->redirect_success = exec_do_redirection(node, d);
+		rd_success = node->command_list->redirect_success;
 		if (operator == EXEC_PIPE)
 			exec_pipe(node, d);
+		else if (!rd_success && operator == EXEC_START && exec_is_builtin(node))
+			return ;
 		else if (operator == EXEC_START && exec_is_builtin(node))
 			return (builtin(node, NULL, true, d));
 		else

--- a/srcs/exec/exec_do_redirection.c
+++ b/srcs/exec/exec_do_redirection.c
@@ -6,7 +6,7 @@
 /*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 16:42:23 by tterao            #+#    #+#             */
-/*   Updated: 2023/09/01 15:05:24 by tatyu            ###   ########.fr       */
+/*   Updated: 2023/09/01 16:36:25 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ static t_redirect_list	*exec_redirect_input(t_redirect_list *node, t_data *d)
 
 	node = node->next;
 	file = node->word;
-	if (node->is_ambiguous_error || file == NULL)
+	if (node->is_ambiguous_error)
 	{
 		exec_put_error_ambiguous_redirect(file, d);
 		return (NULL);
@@ -54,7 +54,7 @@ static t_redirect_list	*exec_redirect_output(t_command *command_list,
 
 	r_node = r_node->next;
 	file = r_node->word;
-	if (r_node->is_ambiguous_error || file == NULL)
+	if (r_node->is_ambiguous_error)
 	{
 		exec_put_error_ambiguous_redirect(file, d);
 		return (NULL);

--- a/srcs/exec/exec_do_redirection.c
+++ b/srcs/exec/exec_do_redirection.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_do_redirection.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 16:42:23 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/31 09:40:46 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/01 15:05:24 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,9 +63,9 @@ static t_redirect_list	*exec_redirect_output(t_command *command_list,
 		fd = try_open(open(file, O_CREAT | O_WRONLY | O_TRUNC, 0644), file, d);
 	else
 		fd = try_open(open(file, O_CREAT | O_WRONLY | O_APPEND, 0644), file, d);
-	exec_close_fd(command_list, d);
 	if (fd == -1)
 		return (NULL);
+	exec_close_fd(command_list, d);
 	command_list->fd = fd;
 	return (r_node);
 }

--- a/srcs/exec/exec_fork.c
+++ b/srcs/exec/exec_fork.c
@@ -6,7 +6,7 @@
 /*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 16:46:09 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/31 09:33:47 by tterao           ###   ########.fr       */
+/*   Updated: 2023/08/31 22:44:49 by tterao           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,5 +33,6 @@ void	exec_fork(t_ast *node, t_data *d)
 	{
 		node->command_list->pid = pid;
 		exec_close_fd(node->command_list, d);
+		try_close(STDIN_FILENO, d);
 	}
 }

--- a/srcs/exec/exec_fork.c
+++ b/srcs/exec/exec_fork.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   exec_fork.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 16:46:09 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/31 22:44:49 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/01 14:56:55 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "exec_command.h"
 
 void	exec_close_fd(t_command *command, t_data *d);
+void	exec_exit_if_redirect_failed(t_ast *node, int *pipefd, t_data *d);
 
 /**
  * @brief この関数はforkを実行し、子プロセスを生成する。
@@ -28,7 +29,10 @@ void	exec_fork(t_ast *node, t_data *d)
 
 	pid = try_fork();
 	if (pid == 0)
+	{
+		exec_exit_if_redirect_failed(node, NULL, d);
 		exec_child_process(node, NULL, d);
+	}
 	else
 	{
 		node->command_list->pid = pid;

--- a/srcs/exec/exec_pipe.c
+++ b/srcs/exec/exec_pipe.c
@@ -3,16 +3,28 @@
 /*                                                        :::      ::::::::   */
 /*   exec_pipe.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 16:59:46 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/31 09:33:29 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/01 15:17:46 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "exec_command.h"
 
 void	exec_close_fd(t_command *command, t_data *d);
+
+void	exec_exit_if_redirect_failed(t_ast *node, int *pipefd, t_data *d)
+{
+	if (node->command_list->redirect_success)
+		return ;
+	if (pipefd != NULL)
+	{
+		try_close(pipefd[R], d);
+		try_close(pipefd[W], d);
+	}
+	exit(d->exit_status);
+}
 
 /**
  * @brief この関数はforkを実行し、子プロセスを生成する。親プロセスは子プロセスの実行結果を受け取る。
@@ -33,7 +45,10 @@ void	exec_pipe(t_ast *node, t_data *d)
 	try_pipe(pipefd);
 	pid = try_fork();
 	if (pid == 0)
+	{
+		exec_exit_if_redirect_failed(node, pipefd, d);
 		exec_child_process(node, pipefd, d);
+	}
 	else
 	{
 		node->command_list->pid = pid;

--- a/srcs/exec/exec_wait_child_process.c
+++ b/srcs/exec/exec_wait_child_process.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_wait_child_process.c                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 16:41:12 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/31 09:24:01 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/01 15:33:40 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 #include "library.h"
 #define SIGNAL_EXITSTATUS 128
 #define SIGINT_EXITSTATUS 130
-#define SIGQUIT_EXITSTATUS 131
 
 void	put_sigquit_line(t_data *d)
 {
@@ -47,9 +46,6 @@ void	exec_wait_child_process(t_ast *node, t_data *d)
 	exec_wait_child_node(node, d);
 	if (node->type != PS_COMMAND)
 		return ;
-	if (node->command_list->pid == -1 && d->exit_status != SIGINT_EXITSTATUS
-		&& d->exit_status != SIGQUIT_EXITSTATUS)
-		d->exit_status = EXIT_FAILURE;
 	else if (node->command_list->pid != -1)
 	{
 		if (try_waitpid(node->command_list->pid, &status, 0, d) == -1)

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,0 @@
-# !/bin/bash
-
-while [ 1 ]; do leaks -q minishell; sleep 1; done


### PR DESCRIPTION
以下のコマンドを対応
```
cat | ls
cat | cat | ls
```