### PR TITLE
186 バグ修正 builtin exit修正

### DIFF
--- a/includes/builtins.h
+++ b/includes/builtins.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/05 12:42:06 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/27 15:39:11 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/09 01:08:06 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,6 @@ void	builtin_pwd(t_data *d);
 void	builtin_export(char **argv, t_data *d);
 void	builtin_unset(char **argv, t_data *d);
 void	builtin_env(char **argv, t_data *d);
-void	builtin_exit(char **argv, t_data *d);
+void	builtin_exit(char **argv, bool is_parent_process, t_data *d);
 
 #endif

--- a/srcs/builtin/builtin.c
+++ b/srcs/builtin/builtin.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 18:53:55 by tatyu             #+#    #+#             */
-/*   Updated: 2023/08/27 22:17:45 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/09 01:08:26 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ void	builtin(t_ast *node, int *pipefd, bool is_parent_process, t_data *d)
 	else if (ft_strcmp_ignorecase(argv[0], "env") == 0)
 		builtin_env(argv, d);
 	else if (ft_strcmp_ignorecase(argv[0], "exit") == 0)
-		builtin_exit(argv, d);
+		builtin_exit(argv, is_parent_process, d);
 	if (dupped_stdoutfd >= 0)
 		reset_stdoutfd(dupped_stdoutfd, d);
 	exec_free_argv(argv);

--- a/srcs/builtin/exit/exit.c
+++ b/srcs/builtin/exit/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/14 16:49:11 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/15 19:52:05 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/09 01:15:01 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,15 +37,19 @@ static bool	is_non_digit_arg(char *str)
 	return (false);
 }
 
-void	builtin_exit(char **argv, t_data *d)
+static void	_exit_(bool is_parent_process, t_data *d)
 {
 	const char	*msg = "exit\n";
 
-	if (argv[1] == NULL)
-	{
+	if (is_parent_process)
 		try_write(STDERR_FILENO, msg, ft_strlen(msg), d);
-		exit(d->exit_status);
-	}
+	exit(d->exit_status);
+}
+
+void	builtin_exit(char **argv, bool is_parent_process, t_data *d)
+{
+	if (argv[1] == NULL)
+		_exit_(is_parent_process, d);
 	if (is_non_digit_arg(argv[1]))
 		exit_put_error_numeric(d, argv[1]);
 	if (exit_is_overflow(argv[1]))
@@ -53,6 +57,5 @@ void	builtin_exit(char **argv, t_data *d)
 	if (argv[2] != NULL)
 		return (exit_put_error_too_many_args(d));
 	d->exit_status = (int)(unsigned char)ft_atol(argv[1]);
-	try_write(STDERR_FILENO, msg, ft_strlen(msg), d);
-	exit(d->exit_status);
+	_exit_(is_parent_process, d);
 }

--- a/srcs/builtin/exit/exit_error.c
+++ b/srcs/builtin/exit/exit_error.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit_error.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 14:26:00 by tterao            #+#    #+#             */
-/*   Updated: 2023/08/15 15:43:16 by tterao           ###   ########.fr       */
+/*   Updated: 2023/09/09 01:18:27 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,7 @@ void	exit_put_error_numeric(t_data *d, char *str)
 	char	*msg;
 
 	d->exit_status = EXIT_NUMERIC_ARG;
-	msg = try_strdup("exit\nexit: ");
-	msg = try_strjoin_free(msg, str);
+	msg = try_strjoin("exit: ", str);
 	msg = try_strjoin_free(msg, ": numeric argument required\n");
 	try_write(STDERR_FILENO, msg, ft_strlen(msg), d);
 	free(msg);
@@ -36,7 +35,7 @@ void	exit_put_error_numeric(t_data *d, char *str)
 
 void	exit_put_error_too_many_args(t_data *d)
 {
-	const char	*msg = "exit\nexit: too many arguments\n";
+	const char	*msg = "exit: too many arguments\n";
 
 	d->exit_status = TOO_MANY_ARGS;
 	try_write(STDERR_FILENO, msg, ft_strlen(msg), d);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/22 13:02:01 by hsawamur          #+#    #+#             */
-/*   Updated: 2023/09/01 14:50:43 by tatyu            ###   ########.fr       */
+/*   Updated: 2023/09/09 01:28:13 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -117,7 +117,8 @@ void	exec_command(t_ast *node, t_operator operator, t_data *d)
 			exec_pipe(node, d);
 		else if (!rd_success && operator == EXEC_START && exec_is_builtin(node))
 			return ;
-		else if (operator == EXEC_START && exec_is_builtin(node))
+		else if ((operator == EXEC_START || operator == EXEC_LOGICAL_AND
+			|| operator == EXEC_LOGICAL_OR) && exec_is_builtin(node))
 			return (builtin(node, NULL, true, d));
 		else
 			exec_fork(node, d);

--- a/srcs/repl.c
+++ b/srcs/repl.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   repl.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tterao <tterao@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tatyu <tatyu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/23 17:35:51 by hsawamur          #+#    #+#             */
-/*   Updated: 2023/09/07 20:51:01 by tyamauch         ###   ########.fr       */
+/*   Updated: 2023/09/09 01:07:05 by tatyu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,7 +84,6 @@ void	read_eval_print_loop(t_data *d)
 		}
 		token = tokenize(line);
 		ast = parse(&token, d);
-		/* debug_print_ast(ast); */
 		if (d->syntax_flag == false && heredoc(ast, d))
 		{
 			expansion(ast, d);


### PR DESCRIPTION
以下を対応しました。
・exit
　□子プロセスで正常に実行される場合、メッセージを出力しない
・builtin
　□ 「&&」「 ||」の次にbuiltinが実行される場合、builtinを親プロセスで実行する