### PR TITLE
redirect の後にオペレーターが来た場合のsyntax_error追加

### DIFF
--- a/srcs/parse/command_redirect_list.c
+++ b/srcs/parse/command_redirect_list.c
@@ -77,8 +77,10 @@ void	command_redirect_list(t_redirect_list **head,
 	if (token_is_quotation_closed(token) == false)
 		ast_syntax_error(d, token);
 	node = redirect_init_node(head, token, redirect_flag);
-	if (redirect_flag == false && token->next == NULL)
+	if (redirect_flag == false && token->next == NULL) 
 		ast_syntax_error(d, NULL);
+	else if (redirect_flag == false && ast_is_opereter(token->next->tk_type))
+		ast_syntax_error(d, token->next);
 	else if (redirect_flag == true && node->re_type == (t_redirect_type)(-1))
 		ast_syntax_error(d, token);
 	redirect_list_addback(head, node);


### PR DESCRIPTION
確認お願いします！

[テスト結果](https://github.com/s1-haya/minishell_bonus/actions/runs/6180314961/job/16776580832)